### PR TITLE
let english version of publish be closer to german version

### DIFF
--- a/publish.md
+++ b/publish.md
@@ -27,14 +27,17 @@ Within public administration, this exchange can serve both to support reuse in t
 and to contribute to standardization through wider dissemination.
 Outside the public administration it serves the transparency as well as the exchange with the economy and can become also nucleus of new Startups.
 
+## Reference Architecture for in-house development
+
 Software in-house development refers to software that is developed by the City of Munich itself.
 This is necessary in cases where no suitable software is available on the market. Examples of this are listed in the chapter "Important activities in 2021".
 The guideline adopted for this purpose defines the technical structure of such self-developed software.
 In accordance with the guideline, a very modern, modular technology stack is used, consisting entirely of open source components:
 the "State Capital Munich Reference Architecture for Self-Development".
 
-
-Abbildung 3: "Munich State Capital Reference Architecture for Own Developments": The architecture stack for software in-house developments consists entirely of open source components
+<TagTile
+:tag-names="['refarchinfrastruktur']"
+/>
 
 In the area of proprietary software developments, which are primarily used where either no solutions can be found on the market,
 or where a very high degree of municipal differentiation is necessary for the City of Munich, open source plays a major role in two ways:


### PR DESCRIPTION
**Description**

i was confused by the part `Abbildung 3: "Munich State Capital Reference Architecture for Own Developments": The architecture stack for software in-house developments consists entirely of open source components` and that the TOC on the right side looked diffrently. So I guess it was intended to have the heading and overview, that is present in the german version, in the english version too.

This is what this PR is providing.

<details>
<summary>Old version</summary>

![grafik](https://github.com/it-at-m/opensource.muenchen.de/assets/13592751/4373723f-b7ec-4bc4-9679-6d73c45105c6)
</details>

<details>
<summary>New version</summary>

![grafik](https://github.com/it-at-m/opensource.muenchen.de/assets/13592751/2c845bf4-e7d9-471c-8e16-3c7c745a0296)
</details>

<details>
<summary>German version</summary>

![grafik](https://github.com/it-at-m/opensource.muenchen.de/assets/13592751/2292b74a-0eed-4f8a-9877-758b36e6e955)
</details>

- @klml 
- @FabianWilms 