### PR TITLE
Add vue i18 n and implement it for tags

### DIFF
--- a/.vitepress/components/TagChip.vue
+++ b/.vitepress/components/TagChip.vue
@@ -1,0 +1,23 @@
+<script setup>
+
+import {TAG_PROP} from "../theme/enhancements/i18n/utility/tags.ts";
+
+const props = defineProps({
+  tag: {
+    type: String,
+    required: true
+  }
+})
+
+const i18nSelectorTags = TAG_PROP;
+
+</script>
+
+<template>
+  <v-chip
+      :value="tag"
+      filter
+  >
+    {{ $t(`${i18nSelectorTags}.${tag}`) }}
+  </v-chip>
+</template>

--- a/.vitepress/components/TagFilter.vue
+++ b/.vitepress/components/TagFilter.vue
@@ -3,6 +3,8 @@ import {ref} from "vue";
 import {computed} from "vue";
 import {data} from "../software.data.js";
 
+import TagChip from "./TagChip.vue";
+
 const props = defineProps({
     modelValue: {
         type: Array,
@@ -39,14 +41,12 @@ const allTags = computed(() => {
             @update:modelValue="$emit('update:modelValue', $event)"
             multiple
     >
-        <v-chip
+        <TagChip
                 v-for="(tag, index) in (availableTags.length > 0 ? availableTags : allTags)"
                 :key="index"
-                :value="tag"
+                :tag="tag"
                 filter
-        >
-            {{ tag }}
-        </v-chip>
+        />
     </v-chip-group>
 </template>
 

--- a/.vitepress/components/TagTile.vue
+++ b/.vitepress/components/TagTile.vue
@@ -50,12 +50,11 @@
                         <div
                                 class="chip-group"
                         >
-                            <v-chip
+                            <TagChip
                                     v-for="(tag, index) in page.frontmatter.tags"
                                     :key="index"
-                            >
-                                {{ tag }}
-                            </v-chip>
+                                    :tag="tag"
+                            />
                         </div>
                     </div>
                 </v-card-text>
@@ -69,6 +68,8 @@
 import {computed} from "vue";
 import {data} from '../software.data.js'
 import {withBase} from "vitepress";
+
+import TagChip from "./TagChip.vue";
 
 const props = defineProps({
     tagNames: {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress'
 import MarkdownItFootnote from 'markdown-it-footnote';
-import { DEFAULT_LANG } from "./theme/enhancements/i18n/messages";
+import { DEFAULT_LANG } from "./theme/enhancements/i18n/i18n";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import MarkdownItFootnote from 'markdown-it-footnote';
+import { DEFAULT_LANG } from "./theme/enhancements/i18n/messages";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -16,7 +17,7 @@ export default defineConfig({
   locales: {
     root: {
       label: 'English',
-      lang: 'en'
+      lang: DEFAULT_LANG
     },
     de: {
       label: 'Deutsch',

--- a/.vitepress/theme/LhmThemeExtension.vue
+++ b/.vitepress/theme/LhmThemeExtension.vue
@@ -2,6 +2,20 @@
 <script setup>
 import DefaultTheme from 'vitepress/theme'
 import SoftwareInfoBox from "./SoftwareInfoBox.vue";
+
+import { useData } from 'vitepress'
+
+import { getCurrentInstance, watch } from 'vue'
+
+const { lang } = useData();
+const currentVueInstance = getCurrentInstance();
+
+currentVueInstance.appContext.config.globalProperties.$i18n.locale = lang.value;
+
+watch(lang, async (newLang) => {
+  currentVueInstance.appContext.config.globalProperties.$i18n.locale = newLang;
+});
+
 const {Layout} = DefaultTheme
 </script>
 <template>

--- a/.vitepress/theme/enhancements/i18n/i18n.ts
+++ b/.vitepress/theme/enhancements/i18n/i18n.ts
@@ -1,0 +1,9 @@
+import { deMessages } from "./lang/de";
+import { enMessages } from "./lang/en";
+
+export const DEFAULT_LANG = "en";
+
+export const messages = {
+    de: deMessages,
+    en: enMessages
+}

--- a/.vitepress/theme/enhancements/i18n/lang/de.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/de.ts
@@ -1,0 +1,24 @@
+import { localizedMessagesType } from "../utility/types";
+
+export const deMessages: localizedMessagesType = {
+    tags: {
+        cicd: "cicd",
+        cms: "cms",
+        client: "client",
+        eigenentwicklung: 'eigententwicklung',
+        foss: "foss",
+        infrastruktur: "infrastruktur",
+        keycloak: "keycloak",
+        kooperation: "kooperation",
+        monitoring: "monitoring",
+        opencore: "opencore",
+        opengovernment: "opengovernment",
+        refarchinfrastruktur: "refarchinfrastruktur",
+        server: "server",
+        schnittstelle: "schnittstelle",
+        sponsor: "sponsor",
+        support: "support",
+        todo: "todo",
+        webanwendung: "webanwendung"
+    }
+};

--- a/.vitepress/theme/enhancements/i18n/lang/en.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/en.ts
@@ -1,0 +1,24 @@
+import { localizedMessagesType } from "../utility/types";
+
+export const enMessages: localizedMessagesType = {
+    tags: {
+        cicd: "cicd",
+        cms: "cms",
+        client: "client",
+        eigenentwicklung: 'inhouse',
+        foss: "foss",
+        infrastruktur: "infrastruktur",
+        keycloak: "keycloak",
+        kooperation: "kooperation",
+        monitoring: "monitoring",
+        opencore: "opencore",
+        opengovernment: "opengovernment",
+        refarchinfrastruktur: "refarchinfrastruktur",
+        server: "server",
+        schnittstelle: "schnittstelle",
+        sponsor: "sponsor",
+        support: "support",
+        todo: "todo",
+        webanwendung: "webanwendung"
+    }
+};

--- a/.vitepress/theme/enhancements/i18n/utility/tags.ts
+++ b/.vitepress/theme/enhancements/i18n/utility/tags.ts
@@ -1,0 +1,22 @@
+export interface Tags {
+    tags: {
+        cicd: string,
+        cms: string,
+        client: string,
+        eigenentwicklung: string,
+        foss: string,
+        infrastruktur: string,
+        keycloak: string,
+        kooperation: string,
+        monitoring: string,
+        opencore: string,
+        opengovernment: string,
+        refarchinfrastruktur: string,
+        server: string,
+        schnittstelle: string,
+        sponsor: string,
+        support: string,
+        todo: string,
+        webanwendung: string,
+    }
+}

--- a/.vitepress/theme/enhancements/i18n/utility/tags.ts
+++ b/.vitepress/theme/enhancements/i18n/utility/tags.ts
@@ -1,5 +1,7 @@
+export const TAG_PROP = "tags";
+
 export interface Tags {
-    tags: {
+    [TAG_PROP]: {
         cicd: string,
         cms: string,
         client: string,

--- a/.vitepress/theme/enhancements/i18n/utility/types.ts
+++ b/.vitepress/theme/enhancements/i18n/utility/types.ts
@@ -1,0 +1,4 @@
+import { DefaultLocaleMessageSchema } from "vue-i18n";
+import { Tags } from "./tags";
+
+export type localizedMessagesType = DefaultLocaleMessageSchema & Tags;

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -5,6 +5,10 @@ import * as components from "vuetify/components"
 import * as directives from "vuetify/directives"
 import "vuetify/styles"
 
+import { createI18n } from "vue-i18n";
+import { messages, DEFAULT_LANG } from "./enhancements/i18n/i18n";
+
+
 import {aliases, mdi} from 'vuetify/iconsets/mdi'
 import '@mdi/font/css/materialdesignicons.css'
 
@@ -23,11 +27,19 @@ const vuetify = createVuetify({
         }
     }
 )
+const i18n = createI18n({
+    legacy: false,
+    fallbackLocale: 'de',
+    messages: messages,
+    locale: DEFAULT_LANG,
+});
 
+console.log('enhace called');
 export default {
     ...DefaultTheme,
     Layout: LhmThemeExtension,
     enhanceApp({app}) {
-        app.use(vuetify)
+        app.use(vuetify);
+        app.use(i18n);
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "markdown-it-footnote": "^3.0.3",
+        "vue-i18n": "^9.5.0",
         "vuetify": "^3.3.21"
       },
       "devDependencies": {
@@ -598,6 +599,47 @@
         "node": ">=12"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.5.0.tgz",
+      "integrity": "sha512-y3ufM1RJbI/DSmJf3lYs9ACq3S/iRvaSsE3rPIk0MGH7fp+JxU6rdryv/EYcwfcr3Y1aHFlCBir6S391hRZ57w==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.5.0",
+        "@intlify/shared": "9.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.5.0.tgz",
+      "integrity": "sha512-CAhVNfEZcOVFg0/5MNyt+OFjvs4J/ARjCj2b+54/FvFP0EDJI5lIqMTSDBE7k0atMROSP0SvWCkwu/AZ5xkK1g==",
+      "dependencies": {
+        "@intlify/shared": "9.5.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.5.0.tgz",
+      "integrity": "sha512-tAxV14LMXZDZbu32XzLMTsowNlgJNmLwWHYzvMUl6L8gvQeoYiZONjY7AUsqZW8TOZDX9lfvF6adPkk9FSRdDA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -686,8 +728,7 @@
     "node_modules/@vue/devtools-api": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
-      "dev": true
+      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.3.4",
@@ -1279,6 +1320,25 @@
         "@vue/shared": "3.3.4"
       }
     },
+    "node_modules/vue-i18n": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.5.0.tgz",
+      "integrity": "sha512-NiI3Ph1qMstNf7uhYh8trQBOBFLxeJgcOxBq51pCcZ28Vs18Y7BDS58r8HGDKCYgXdLUYqPDXdKatIF4bvBVZg==",
+      "dependencies": {
+        "@intlify/core-base": "9.5.0",
+        "@intlify/shared": "9.5.0",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vuetify": {
       "version": "3.3.21",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.21.tgz",
@@ -1661,6 +1721,29 @@
       "dev": true,
       "optional": true
     },
+    "@intlify/core-base": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.5.0.tgz",
+      "integrity": "sha512-y3ufM1RJbI/DSmJf3lYs9ACq3S/iRvaSsE3rPIk0MGH7fp+JxU6rdryv/EYcwfcr3Y1aHFlCBir6S391hRZ57w==",
+      "requires": {
+        "@intlify/message-compiler": "9.5.0",
+        "@intlify/shared": "9.5.0"
+      }
+    },
+    "@intlify/message-compiler": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.5.0.tgz",
+      "integrity": "sha512-CAhVNfEZcOVFg0/5MNyt+OFjvs4J/ARjCj2b+54/FvFP0EDJI5lIqMTSDBE7k0atMROSP0SvWCkwu/AZ5xkK1g==",
+      "requires": {
+        "@intlify/shared": "9.5.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "@intlify/shared": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.5.0.tgz",
+      "integrity": "sha512-tAxV14LMXZDZbu32XzLMTsowNlgJNmLwWHYzvMUl6L8gvQeoYiZONjY7AUsqZW8TOZDX9lfvF6adPkk9FSRdDA=="
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -1749,8 +1832,7 @@
     "@vue/devtools-api": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
-      "dev": true
+      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
     },
     "@vue/reactivity": {
       "version": "3.3.4",
@@ -2104,6 +2186,16 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
+      }
+    },
+    "vue-i18n": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.5.0.tgz",
+      "integrity": "sha512-NiI3Ph1qMstNf7uhYh8trQBOBFLxeJgcOxBq51pCcZ28Vs18Y7BDS58r8HGDKCYgXdLUYqPDXdKatIF4bvBVZg==",
+      "requires": {
+        "@intlify/core-base": "9.5.0",
+        "@intlify/shared": "9.5.0",
+        "@vue/devtools-api": "^6.5.0"
       }
     },
     "vuetify": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "markdown-it-footnote": "^3.0.3",
+    "vue-i18n": "^9.5.0",
     "vuetify": "^3.3.21"
   }
 }


### PR DESCRIPTION
**Description**

- add vueI18N
- a watcher was added in the extended layout
- I created a new component `TagChip`
  - the chip was used multiple times
  - have to implement the i18n connection only in one place
- create files for en and de
- if a tag is missing `tags.missingTagName` is displayed
- i didn't converted existing tags to English
- its visible at tag `eigenentwicklung`
- [ ] another developer should review my code, special in `.vitepress/theme/LhmThemeExtension.vue`. `useI18N` didnt worked as expected so i have choosen that way

---

**Screenshots**

<details>

<summary>en-version</summary>

![grafik](https://github.com/it-at-m/opensource.muenchen.de/assets/13592751/427fc3e9-5ed3-40bb-a0b3-3950c0e6974d)

</details>

<details>

<summary>ger-version</summary>

![grafik](https://github.com/it-at-m/opensource.muenchen.de/assets/13592751/46efb1fb-2cc6-4f4a-a5e0-fbd4622d6ea4)

</details>

**Reference**

Issues #20 
