### PR TITLE
:sparkles: allow navigating to url without trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM ghcr.io/ks-no/openshift-nginx/fiks-nginx-openshift:latest
+
+# Custom NGINX-Config to allow URLs without trailing slashes #75
+COPY nginx.rewriteslashes.conf /etc/nginx/conf.d/default.conf
+# Copy built Vitepress page
 COPY .vitepress/dist/ /usr/share/nginx/html
 
 LABEL org.opencontainers.image.title="opensource.muenchen.de"

--- a/nginx.rewriteslashes.conf
+++ b/nginx.rewriteslashes.conf
@@ -1,0 +1,18 @@
+server {
+    listen 8081;
+    server_name  localhost;
+
+    # Rewrite all URLs not containing a "." to end with a Slash,
+    # so that you are able to navigate to a Page without a trailing slash.
+    rewrite ^([^.]*[^/])$ $1/ permanent;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
**Description**

Configuring nginx to redirect URLs without trailing slash

I copied the base config from the original nginx container:

```bash
~ $ cat /etc/nginx/conf.d/default.conf
server {
    listen 8081;
    server_name  localhost;

    #access_log  /var/log/nginx/host.access.log  main;

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }

    #error_page  404              /404.html;

    # redirect server error pages to the static page /50x.html
    #
    error_page   500 502 503 504  /50x.html;
    location = /50x.html {
        root   /usr/share/nginx/html;
    }

    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
    #
    #location ~ \.php$ {
    #    proxy_pass   http://127.0.0.1;
    #}

    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
    #
    #location ~ \.php$ {
    #    root           html;
    #    fastcgi_pass   127.0.0.1:9000;
    #    fastcgi_index  index.php;
    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
    #    include        fastcgi_params;
    #}

    # deny access to .htaccess files, if Apache's document root
    # concurs with nginx's one
    #
    #location ~ /\.ht {
    #    deny  all;
    #}
}
```

**Reference**

Issues #75
