### PR TITLE
remove file extension .html

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -5,6 +5,7 @@ const base = '/';
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
+  cleanUrls: true,
   base: base,
   srcExclude: [
       'README.md'


### PR DESCRIPTION
cleaning routes from `https://opensource.muenchen.de/use.html` to `https://opensource.muenchen.de/use`

**Reference**
https://github.com/it-at-m/opensource.muenchen.de/issues/104