### PR TITLE
Update and rename pentaho.md to pentaho-carte.md

### DIFF
--- a/de/software/pentaho-carte.md
+++ b/de/software/pentaho-carte.md
@@ -1,6 +1,6 @@
 ---
 Source: SNow
-title: Pentaho
+title: Pentaho Carte Server
 developer: null
 developerlink: https://www.hitachivantara.com/en-us/products/pentaho-plus-platform/data-integration-analytics/pentaho-community-edition.html
 licensingmodel: open source
@@ -8,7 +8,8 @@ license: LGPL
 logo: /logo/320px-Pentaho2.JPG
 tags:
 - application
+- development
 ---
-Pentaho ist eine Sammlung von Business-Intelligence-Software, die in einer Basisversion Open Source ist. 
+Der Pentaho Carte Server ist Teil der Datenintegrationsplattform Pentaho Data Integration zum Erfassen, Mischen, Bereinigen und Vorbereiten verschiedener Daten aus beliebigen Quellen in einer beliebigen Umgebung ohne Code.
 
 ---


### PR DESCRIPTION
**Description**

- Renaming because only pentaho carte server is used which is part of pentaho data integraiton platform
- New tag development:  It's an application used for development.

