### PR TITLE
use github dependency review for license compliance

### DIFF
--- a/de/licenses.md
+++ b/de/licenses.md
@@ -54,10 +54,10 @@ Das bedeutet, Software die OpenJDK nutzt muss nicht zwangsläufig unter der GPL 
 
 Um sicherzustellen, dass wir keine Lizenzverstöße begehen, müssen sämtliche Abhängigkeiten unserer Software geprüft und dokumentiert werden.
 
-Auf Github nutzen wir dazu [advanced-security/policy-as-code](https://github.com/marketplace/actions/ghas-policy-as-code), das ist im [oss-repository-en-template](https://github.com/it-at-m/oss-repository-en-template/blob/main/.github/workflows/build.yaml#L13) bereits vorgegeben.
+Auf Github nutzen wir dazu [GitHub Dependency Review](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review), das ist im [oss-repository-en-template](https://github.com/it-at-m/oss-repository-en-template/blob/main/.github/workflows/dependency_review.yaml) bereits vorgegeben.
 
-Das **zentrale it@M Policy File** ist definiert in [it-at-m/policy-as-code](https://github.com/it-at-m/policy-as-code) - [dort sind v.a. die Lizenzen mit starken Copyleft definiert](https://github.com/it-at-m/policy-as-code/blob/main/default.yaml#L12), die wir vermeiden wollen.
+Das **zentrale it@M Policy File** ist definiert in [it-at-m/.github](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml) - [dort sind v.a. die Lizenzen mit starken Copyleft definiert](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml#L2), die wir vermeiden wollen.
 
-Da es bei der Lizenzerkennung durchaus zu "false positives" kommen kann, können diese dort auf eine [Ignore-Liste](https://github.com/it-at-m/policy-as-code/blob/main/default.yaml#L23) gesetzt werden.
+Da es bei der Lizenzerkennung durchaus zu "false positives" kommen kann, können diese dort auf eine [Ignore-Liste](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml#L6) gesetzt werden.
 
 Die Kompatibilität der genutzten Lizenzen können mit dem [JLA - Compatibility Checker](https://joinup.ec.europa.eu/collection/eupl/solution/joinup-licensing-assistant/jla-compatibility-checker) geprüft werden.

--- a/licenses.md
+++ b/licenses.md
@@ -53,10 +53,10 @@ This means that software that uses OpenJDK does not necessarily have to be licen
 
 To ensure that we do not commit any licence violations, all dependencies of our software must be checked and documented.
 
-We use [advanced-security/policy-as-code](https://github.com/marketplace/actions/ghas-policy-as-code) on Github for this purpose, which is already predefined in [oss-repository-en-template](https://github.com/it-at-m/oss-repository-en-template/blob/main/.github/workflows/build.yaml#L13).
+We use [GitHub Dependency Review](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) for this purpose, which is already predefined in [oss-repository-en-template](https://github.com/it-at-m/oss-repository-en-template/blob/main/.github/workflows/dependency_review.yaml).
 
-The **central it@M policy file** is defined in [it-at-m/policy-as-code](https://github.com/it-at-m/policy-as-code) - [the licences with a strong copyleft are defined there](https://github.com/it-at-m/policy-as-code/blob/main/default.yaml#L12), which we want to avoid.
+The **central it@M policy file** is defined in [it-at-m/.github](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml) - [the licences with a strong copyleft are defined there](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml#L2), which we want to avoid.
 
-As "false positives" can occur during licence detection, these can be placed on an [ignore list](https://github.com/it-at-m/policy-as-code/blob/main/default.yaml#L23).
+As "false positives" can occur during licence detection, these can be placed on an [ignore list](https://github.com/it-at-m/.github/blob/main/workflow-configs/dependency_review.yaml#L6).
 
 The compatibility of the licences used can be checked with the [JLA - Compatibility Checker](https://joinup.ec.europa.eu/collection/eupl/solution/joinup-licensing-assistant/jla-compatibility-checker).


### PR DESCRIPTION
**Description**

Switch from to GitHub Dependency Review for licence compliance check.

**Reference**

Internal issue https://git.muenchen.de/ccse/ospo/-/issues/171
