### PR TITLE
typo: duplication "permanent"

### DIFF
--- a/sabbatical.md
+++ b/sabbatical.md
@@ -30,7 +30,7 @@ The following compensation options are currently offered
 
 ### External software developers
 
-A __permanent permanent position__ is generally possible with a six-month material reason.
+A __permanent position__ is generally possible with a six-month material reason.
 
 A fixed-term permanent position is possible via the digital consulting company of the City of Munich [digital@M](https://digital-at-m.de/).
 Our target for financial compensation is 60% of the usual salary.


### PR DESCRIPTION
**Description**

the text has a word duplication in "A permanent _permanent_ position is generally possible with a six-month material reason."
This PR removes the word duplication.

**Reference**

none. this is a drive-by fix. take it or leave it :-)
