### PR TITLE
Adjustment of legal basis in impress

### DIFF
--- a/de/impress.md
+++ b/de/impress.md
@@ -43,9 +43,9 @@ Da Sie sich als Besucher weder registrieren noch einloggen können, erheben wir 
 
 IP-Adresse, Datum und Uhrzeit der Anfrage, Zeitzonendifferenz zur Greenwich Mean Time, Inhalt der Anforderung, HTTP-Statuscode, übertragene Datenmenge, Website, von der die Anforderung kommt und Informationen zu Browser und Betriebssystem.
 
-Das ist erforderlich, um unsere Website anzuzeigen und die Stabilität und Sicherheit zu gewährleisten. Dies entspricht unserem berechtigten Interesse im Sinne des Art. 6 Abs. 1 S. 1 lit. f DSGVO.
+Das ist erforderlich, um unsere Website anzuzeigen und die Stabilität und Sicherheit zu gewährleisten. Dies entspricht unserem berechtigten Interesse im Sinne des Art. 6 Abs. 1 lit. e) DSGVO i.V.m. Art. 4 BayDSG.
 
-Dieser ist Empfänger Ihrer personenbezogenen Daten und als Auftragsverarbeiter für uns tätig. Dies entspricht unserem berechtigten Interesse im Sinne des Art. 6 Abs. 1 S. 1 lit. f DSGVO, selbst keinen Server in unseren Räumlichkeiten vorhalten zu müssen. Serverstandort ist Deutschland.
+Dieser ist Empfänger Ihrer personenbezogenen Daten und als Auftragsverarbeiter für uns tätig. Dies entspricht unserem berechtigten Interesse im Sinne des Art. 6 Abs. 1 lit. e) DSGVO i.V.m. Art. 4 BayDSG, selbst keinen Server in unseren Räumlichkeiten vorhalten zu müssen. Serverstandort ist Deutschland.
 
 Sie haben das Recht der Verarbeitung zu widersprechen. Ob der Widerspruch erfolgreich ist, ist im Rahmen einer Interessenabwägung zu ermitteln.
 

--- a/impress.md
+++ b/impress.md
@@ -43,9 +43,9 @@ Since you cannot register or log in as a visitor, we only collect the following 
 
 IP address, date and time of the request, time zone difference to Greenwich Mean Time, content of the request, HTTP status code, amount of data transferred, website from which the request comes and information about the browser and operating system.
 
-This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR para. 4 BayDSG.
+This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR i.V.m.para. 4 BayDSG.
 
-This is the recipient of your personal data and acts as a processor for us. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR para. 4 BayDSG in not having to maintain a server on our premises ourselves. The server location is Germany.
+This is the recipient of your personal data and acts as a processor for us. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR i.V.m. para. 4 BayDSG in not having to maintain a server on our premises ourselves. The server location is Germany.
 
 You have the right to object to the processing. Whether the objection is successful must be determined as part of a balancing of interests.
 

--- a/impress.md
+++ b/impress.md
@@ -43,7 +43,7 @@ Since you cannot register or log in as a visitor, we only collect the following 
 
 IP address, date and time of the request, time zone difference to Greenwich Mean Time, content of the request, HTTP status code, amount of data transferred, website from which the request comes and information about the browser and operating system.
 
-This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR i.V.m.para. 4 BayDSG.
+This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR i.V.m. para. 4 BayDSG.
 
 This is the recipient of your personal data and acts as a processor for us. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR i.V.m. para. 4 BayDSG in not having to maintain a server on our premises ourselves. The server location is Germany.
 

--- a/impress.md
+++ b/impress.md
@@ -43,9 +43,9 @@ Since you cannot register or log in as a visitor, we only collect the following 
 
 IP address, date and time of the request, time zone difference to Greenwich Mean Time, content of the request, HTTP status code, amount of data transferred, website from which the request comes and information about the browser and operating system.
 
-This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. f GDPR.
+This is necessary to display our website and to ensure stability and security. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR para. 4 BayDSG.
 
-This is the recipient of your personal data and acts as a processor for us. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. f GDPR in not having to maintain a server on our premises ourselves. The server location is Germany.
+This is the recipient of your personal data and acts as a processor for us. This corresponds to our legitimate interest within the meaning of Art. 6 para. 1 sentence 1 lit. e) GDPR para. 4 BayDSG in not having to maintain a server on our premises ourselves. The server location is Germany.
 
 You have the right to object to the processing. Whether the objection is successful must be determined as part of a balancing of interests.
 


### PR DESCRIPTION
We had a conversation with the legal department about `ki.muenchen.de`, who told us that the legal basis is not quite correct. Should also affect `opensource.muenchen.de`. Here is the change.

Our change in ki.muenchen.de:
https://github.com/it-at-m/ki.muenchen.de/pull/7