### PR TITLE
Metadatenkatalog

### DIFF
--- a/de/software/ckan.md
+++ b/de/software/ckan.md
@@ -19,8 +19,8 @@ __CKAN__ (Comprehensive Knowledge Archive Network) ist eine webbasierte Datenkat
 
 Wir verwenden CKAN in zwei Projekten:
 
-Über das Portal [opendata.muenchen.de](https://opendata.muenchen.de) wird das Angebot der Landeshauptstadt München an offenen Daten publiziert und in unterschiedlichsten Visualisierungen angeboten.
-
+* Über das öffentliche Portal [opendata.muenchen.de](https://opendata.muenchen.de) wird das Angebot der Landeshauptstadt München an offenen Daten publiziert und in unterschiedlichsten Visualisierungen angeboten.
+* Der Metadatenkatalog (MDK) ist der interne zentrale Katalog für Metadaten aller Daten, Dienste und Anwendungen (z.B. Portale) des Digitalen Zwillings München. Er ermöglicht die zentrale Recherche nach verfügbaren Daten des Geodatenpools.
 Im Rahmen des Projekts [Connected Urban Twins](https://www.connectedurbantwins.de) (CUT) entwickelt München zusammen mit Hamburg und Leipzig den Digitalen Zwilling.
 Die Entwicklung der Projekte erfolgt nutzerorientiert und modular.
 [Alle Projektergebnisse werden frühzeitig geteilt und als „Open Source“ zur Verfügung gestellt.](https://stadt.muenchen.de/infos/connected-urban-twins.html), so wie es die [Regelungen zu Open Source für Modellprojekte Smart Cities des Bundesministerium für Wohnen, Stadtentwicklung und Bauwesen ](https://www.smart-city-dialog.de/regelungen-zu-open-source-fuer-modellprojekte-smart-cities) vorsehen.

--- a/software/ckan.md
+++ b/software/ckan.md
@@ -18,8 +18,8 @@ __CKAN__ (Comprehensive Knowledge Archive Network) is a web-based data catalog s
 
 We use CKAN in two projects:
 
-The portal [opendata.muenchen.de](https://opendata.muenchen.de) publishes the open data offered by the state capital of Munich and offers it in a wide variety of visualizations.
-
+* The public portal [opendata.muenchen.de](https://opendata.muenchen.de) publishes the City of Munich's range of open data and offers it in a wide variety of visualizations.
+* The metadata catalog (MDK) is the internal central catalog for metadata of all data, services and applications (e.g. portals) of the Munich digital twin. It enables centralized searches for available data from the geodata pool.
 As part of the [Connected Urban Twins](https://www.connectedurbantwins.de) project (CUT), Munich is developing the digital twin together with Hamburg and Leipzig.
 The development of the projects is user-oriented and modular.
 [All project results are shared at an early stage and made available as "open source"](https://stadt.muenchen.de/infos/connected-urban-twins.html), as stipulated by the [Regulations on Open Source for Model Projects Smart Cities of the Federal Ministry of Housing, Urban Development and Construction ](https://www.smart-city-dialog.de/regelungen-zu-open-source-fuer-modellprojekte-smart-cities).


### PR DESCRIPTION
**Description**

The metadata catalog (MDK) is the internal central catalog for metadata of all data, services and applications (e.g. portals) of the Munich digital twin. It enables centralized searches for available data from the geodata pool.
