### PR TITLE
Add security.md (de & en)

### DIFF
--- a/de/security.md
+++ b/de/security.md
@@ -1,0 +1,53 @@
+# Security
+
+Software Security ist vor allem bei der Verarbeitung und Speicherung von personenbezogenen Daten eine wichtige Voraussetzung. Dies gilt insbesondere auch für veröffentlichte Software.
+
+## Grundlegendes Verständnis für Sicherheitsrelevante Aspekte
+
+Beitragende Entwickler sollten – wie alle Entwickler – über ein grundlegendes Verständnis sicherheitsrelevanter Aspekte verfügen. Die folgenden Punkte sind hierbei von besonderer Bedeutung:
+
+1. **Keine Veröffentlichung von Passwörtern**: Es ist zwingend zu vermeiden, Passwörter (z. B. für Datenbanken oder externe Dienste) zu veröffentlichen. Passwörter dürfen in keinem Git-Repository erscheinen, unabhängig davon, ob es sich um lokale Repositories, git.muenchen.de oder github.com handelt. Sollte es dennoch zu einem Vorfall kommen, ist dies zwar bedauerlich, aber nicht ungewöhnlich. In einem solchen Fall müssen die entsprechenden Daten umgehend ausgetauscht werden. Dies könnte zusätzlichen Aufwand verursachen, beispielsweise die Kontaktaufnahme mit dem Datenbankteam, ist jedoch unerlässlich. Das alte Passwort ist in diesem Kontext ohnehin nicht mehr verwendbar und muss nicht zwingend aus der Git-Historie entfernt werden.
+
+2. **Vertraulichkeit von Infrastruktur-Daten**: Es ist ebenfalls unerlässlich, Infrastruktur-Daten (z.B. Infrastructure as Code (IaC), OpenShift-Objekte, IP-Adressen und interne Domains) nicht zu veröffentlichen. Obwohl dies nicht so gravierend ist wie die Offenlegung von Passwörtern, sollten die spezifischen Infrastruktur-Einstellungen der LHM stets vom Applikationscode getrennt und in einem separaten Infrastruktur-Git-Repository abgelegt werden.
+
+3. **Vermeidung der Nennung von Personen**: In Kommentaren sollten keine Namen von Personen erwähnt werden, die nicht direkt im GitHub-Repository mitwirken. Zum Beispiel sollten fachliche Anforderungen nicht mit Formulierungen wie „Herr Maier hat sich gewünscht …“ versehen werden.
+
+4. **Sensible Daten in Logausgaben**: Es ist darauf zu achten, dass keine sensiblen Daten in Logausgaben erscheinen.
+
+5. **Fehlerdetails in Frontendausgaben**: Zudem sollten keine detaillierten Fehlermeldungen in den Frontendausgaben angezeigt werden.
+
+6. **Externe Quellen**: Das Nachladen von Ressourcen aus externen Quellen, wie beispielsweise JavaScript-Bibliotheken, sollte vermieden werden.
+
+7. **Kryptografische Logik**: Die Implementierung eigener kryptografischer Logik ist zu unterlassen, um Sicherheitsrisiken zu vermeiden.
+
+8. **Cookies**: Bei der Verwendung von Cookies sollte darauf geachtet werden, dass, wo immer möglich, die Attribute „Secure“, „HttpOnly“ und „SameSite“ verwendet werden.
+
+Durch die Beachtung dieser Grundsätze kann die Sicherheit der Software erheblich verbessert werden.
+
+## Meldung von Sicherheitsanfälligkeiten
+
+Im Gegensatz zu anderen Plattformen wie GitLab bietet GitHub keine Möglichkeit zur vertraulichen Meldung von Sicherheitsproblemen. Daher sollten sicherheitsrelevante Bugs nicht als öffentliche, normale Probleme (Issues) gemeldet werden. Jedes Projekt muss die E-Mail-Adresse opensource@muenchen.de angeben, um sicherheitsrelevante Bugs zu melden.
+
+## Automatisierte Tests
+
+Im internen Continuous Integration/Continuous Deployment (CI/CD) Prozess ist der OWASP Dependency Check integriert, der zur Risikoanalyse zwingend in den Build-Prozess einbezogen werden muss. 
+
+Auf GitHub sollte in den Aktionen die "Advanced Security Policy as Code" integriert werden. Für alle Repositories muss die globale Sicherheitskonfiguration "it@M Security Config" (nur für Administratoren) aktiviert werden. Diese Konfiguration umfasst unter anderem:
+
+- **Push-Schutz**: Blockiert Commits, die unterstützte geheime Daten enthalten.
+
+Zusätzlich sollte der Renovate-Bot aktiviert werden, um Fixes für Dependabot-Alerts zu ermöglichen (Standardkonfiguration). Es ist wichtig, alle Sicherheitswarnungen im Sicherheitsbereich der Repositories zu beachten und entsprechend zu bearbeiten.
+
+Alle geöffneten Pull Requests (PR) und Issues müssen zeitnah, innerhalb von zwei Wochen, bearbeitet werden. Nach Ablauf dieser Frist werden alle offenen PR und Issues dem Maintainer des Repositories zur weiteren Bearbeitung zugewiesen. Das Team "itm-security" wird über offene Alerts informiert und wird aktiv auf die betreffenden Teams zugehen.
+
+## Öffentliche Sicherheitstests
+
+MGM Security Partners führt öffentliche Sicherheitstests (Penetrationstests) für freie und Open Source Software (FOSS) durch. In der Vergangenheit hat das Bundesamt für Sicherheit in der Informationstechnik (BSI) den Quellcode des Messenger-Dienstes Matrix und der Social-Media-Anwendung Mastodon überprüft und dabei Sicherheitsanfälligkeiten entdeckt.
+In den Ergebnisberichten behält sich MGM das Recht vor, die Texte und Formate im Vergleich zu vertraulichen Tests anzupassen, sodass sie veröffentlicht werden können. 
+
+## Weblinks
+
+Falls Unklarheiten zu bestimmten Punkten bestehen, wird empfohlen, einen Blick auf die folgenden Ressourcen zu werfen:
+
+- [IT-Grundschutz-Kompendium](https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/IT-Grundschutz/IT-Grundschutz-Kompendium/it-grundschutz-kompendium_node.html)
+- [OWASP-Liste](https://owasp.org/www-project-top-ten/)

--- a/security.md
+++ b/security.md
@@ -1,0 +1,52 @@
+# Security
+
+Software security is a crucial requirement, especially when processing and storing personal data. This is particularly true for published software.
+
+## Basic Understanding of Security-Relevant Aspects
+
+Contributing developers should – like all developers – possess a fundamental understanding of security-relevant aspects. The following points are of particular importance:
+
+1. **No Publication of Passwords**: It is essential to avoid publishing passwords (e.g., for databases or external services). Passwords must not appear in any Git repository, whether local, on git.muenchen.de, or github.com. Should an incident occur, it is unfortunate but not uncommon. In such cases, the relevant data must be promptly replaced. This may involve additional effort, such as contacting the database team, but it is imperative. The old password is no longer usable in this context and does not necessarily need to be removed from the Git history.
+
+2. **Confidentiality of Infrastructure Data**: It is also crucial to refrain from publishing infrastructure data (e.g., Infrastructure as Code (IaC), OpenShift objects, IP addresses, and internal domains). Although this is not as severe as disclosing passwords, the specific infrastructure settings should always be separated from the application code and stored in a separate infrastructure Git repository.
+
+3. **Avoid Mentioning Individuals**: Comments should not mention the names of individuals who do not directly contribute to the GitHub repository. For example, technical requirements should not be phrased as “Mr. Maier has requested …”.
+
+4. **Sensitive Data in Log Outputs**: Care must be taken to ensure that no sensitive data appears in log outputs.
+
+5. **Error Details in Frontend Outputs**: Additionally, detailed error messages should not be displayed in frontend outputs.
+
+6. **External Sources**: The loading of resources from external sources, such as JavaScript libraries, should be avoided.
+
+7. **Cryptographic Logic**: The implementation of custom cryptographic logic should be avoided to mitigate security risks.
+
+8. **Cookies**: When using cookies, it is important to ensure that the attributes “Secure,” “HttpOnly,” and “SameSite” are used wherever possible.
+
+By adhering to these principles, the security of the software can be significantly enhanced.
+
+## Reporting Security Vulnerabilities
+
+Unlike other platforms such as GitLab, GitHub does not provide a means for confidential reporting of security issues. Therefore, security-related bugs should not be reported as public, normal issues. Each project must provide the email address opensource@muenchen.de for reporting security-related bugs.
+
+## Automated Testing
+
+The internal Continuous Integration/Continuous Deployment (CI/CD) process includes the OWASP Dependency Check, which must be integrated into the build process for risk analysis.
+
+On GitHub, the "Advanced Security Policy as Code" should be incorporated into the actions. The global security configuration "it@M Security Config" (for administrators only) must be activated for all repositories. This configuration includes:
+
+- **Push Protection**: Blocks commits that contain supported secret data.
+
+Additionally, the Renovate Bot should be activated to enable fixes for Dependabot alerts (default configuration). It is important to monitor and address all security alerts in the security tab of the repositories.
+
+All open Pull Requests (PR) and issues must be addressed within two weeks. After this period, all open PRs and issues will be assigned to the maintainer of the repository for further handling. The "itm-security" team will be notified of open alerts and will actively reach out to the relevant teams.
+
+## Public Security Tests
+
+MGM Security Partners conducts public security tests (penetration tests) for free and open source software (FOSS). In the past, the Federal Office for Information Security (BSI) has reviewed the source code of the messaging service Matrix and the social media application Mastodon, discovering security vulnerabilities in the process. In the result reports, MGM reserves the right to adjust the texts and formats compared to confidential tests so that they can be published.
+
+## Web Links
+
+If there are uncertainties regarding specific points, it is recommended to take a look at the following resources:
+
+- [IT-Grundschutz-Kompendium](https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/IT-Grundschutz/IT-Grundschutz-Kompendium/it-grundschutz-kompendium_node.html)
+- [OWASP List](https://owasp.org/www-project-top-ten/)


### PR DESCRIPTION
**Description**

Add security.md in german and englisch. Content rewritten from [git.muenchen.de](https://git.muenchen.de/ccse/ospo/-/wikis/Security).


