### PR TITLE
opencode-ehren-kiwi

### DIFF
--- a/de/software/ehrenamtjustiz.md
+++ b/de/software/ehrenamtjustiz.md
@@ -2,6 +2,7 @@
 title: Ehrenamtjustiz
 developer: LHM
 code: https://github.com/it-at-m/ehrenamt-justiz
+opencode: https://opencode.de/de/software/ehrenamt-justiz-9560
 licensingmodel: open source
 license: MIT
 tags:

--- a/de/software/kiwi.md
+++ b/de/software/kiwi.md
@@ -1,6 +1,7 @@
 ---
 title: Kiwi - Unicode Tastatur
 code: https://github.com/it-at-m/UnicodeEingabeKiwi2
+opencode: https://opencode.de/de/software/kiwi-9766
 licensingmodel: open source
 linkapplication: https://kiwi.muenchen.de
 logo: https://kiwi.muenchen.de/images/Kiwi-Bird-Logo.svg

--- a/software/ehrenamtjustiz.md
+++ b/software/ehrenamtjustiz.md
@@ -2,7 +2,7 @@
 title: Ehrenamtjustiz
 developer: LHM
 code: https://github.com/it-at-m/ehrenamt-justiz
-opencode: https://opencode.de/de/software/ehrenamt-justiz-9560
+opencode: https://opencode.de/en/software/ehrenamt-justiz-9560
 licensingmodel: open source
 license: MIT
 tags:

--- a/software/ehrenamtjustiz.md
+++ b/software/ehrenamtjustiz.md
@@ -2,6 +2,7 @@
 title: Ehrenamtjustiz
 developer: LHM
 code: https://github.com/it-at-m/ehrenamt-justiz
+opencode: https://opencode.de/de/software/ehrenamt-justiz-9560
 licensingmodel: open source
 license: MIT
 tags:

--- a/software/kiwi.md
+++ b/software/kiwi.md
@@ -1,6 +1,7 @@
 ---
 title: Kiwi - Unicode Tastatur
 code: https://github.com/it-at-m/UnicodeEingabeKiwi2
+opencode: https://opencode.de/de/software/kiwi-9766
 licensingmodel: open source
 linkapplication: https://kiwi.muenchen.de
 logo: https://kiwi.muenchen.de/images/Kiwi-Bird-Logo.svg

--- a/software/kiwi.md
+++ b/software/kiwi.md
@@ -1,7 +1,7 @@
 ---
 title: Kiwi - Unicode Tastatur
 code: https://github.com/it-at-m/UnicodeEingabeKiwi2
-opencode: https://opencode.de/de/software/kiwi-9766
+opencode: https://opencode.de/en/software/kiwi-9766
 licensingmodel: open source
 linkapplication: https://kiwi.muenchen.de
 logo: https://kiwi.muenchen.de/images/Kiwi-Bird-Logo.svg


### PR DESCRIPTION
add opencode ehrenamt and kiwi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added opencode registry links for the EhrenamtJustiz and Kiwi projects, exposing direct access to their registry pages from project metadata.
  * Updated German and English project entries to include the new external opencode references, with no other content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->