### PR TITLE
feat: add VitePress local search support

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -57,6 +57,7 @@ export default defineConfig({
           },
         ],
 
+        search: { provider: 'local' },
         sidebar: [],
         outline: {
           label: "Auf dieser Seite",
@@ -116,6 +117,7 @@ export default defineConfig({
       message: `<a href="/impress.html">Impress and Contact</a> | <a href="/accessibility.html">Accessibility</a>`,
     },
 
+    search: { provider: 'local' },
     sidebar: [],
 
     outline: {


### PR DESCRIPTION
**Closes issue #351**

This PR adds search functionality using the built-in VitePress default theme search.

Changes made:
- enabled local search in the VitePress config
- verified the site runs locally with the new search config

**[Reference](https://vitepress.dev/reference/default-theme-search)**

Issues #351 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled local search provider for the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->