### PR TITLE
feat: add clear all action for selected tags

### DIFF
--- a/.vitepress/components/TagFilter.vue
+++ b/.vitepress/components/TagFilter.vue
@@ -15,7 +15,7 @@ const props = defineProps({
   },
 });
 
-defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue"]);
 
 const selectedTags = ref([]);
 
@@ -30,6 +30,10 @@ const allTags = computed(() => {
 
   return allTags;
 });
+
+function clearAll() {
+  emit("update:modelValue", []);
+}
 
 function getCountOfTag(tag) {
   let counter = 0;
@@ -48,6 +52,16 @@ function getCountOfTag(tag) {
 </script>
 
 <template>
+  <div>
+  <v-chip
+      v-if="modelValue.length > 1"
+      size="small"
+      color="primary"
+      variant="outlined"
+      @click="clearAll"
+    >
+      Clear All
+    </v-chip>
   <v-chip-group
     :model-value="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
@@ -61,6 +75,6 @@ function getCountOfTag(tag) {
       filter
     />
   </v-chip-group>
+  </div>
 </template>
-
 <style scoped></style>

--- a/.vitepress/components/TagFilter.vue
+++ b/.vitepress/components/TagFilter.vue
@@ -3,6 +3,7 @@ import { computed, ref } from "vue";
 
 import { data } from "../software.data.js";
 import TagChip from "./TagChip.vue";
+import { useTranslator } from "./Translator.ts";
 
 const props = defineProps({
   modelValue: {
@@ -16,6 +17,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["update:modelValue"]);
+const { t } = useTranslator();
 
 const selectedTags = ref([]);
 
@@ -34,7 +36,6 @@ const allTags = computed(() => {
 function clearAll() {
   emit("update:modelValue", []);
 }
-
 function getCountOfTag(tag) {
   let counter = 0;
   for (let softwareEntry of data) {
@@ -53,28 +54,31 @@ function getCountOfTag(tag) {
 
 <template>
   <div>
-  <v-chip
+    <v-chip
       v-if="modelValue.length > 1"
       size="small"
       color="primary"
       variant="outlined"
       @click="clearAll"
     >
-      Clear All
+      {{ t("TagFilter.clearAll") }}
     </v-chip>
-  <v-chip-group
-    :model-value="modelValue"
-    @update:modelValue="$emit('update:modelValue', $event)"
-    multiple
-  >
-    <tag-chip
-      v-for="(tag, index) in availableTags.length > 0 ? availableTags : allTags"
-      :key="index"
-      :tag="tag"
-      :count="getCountOfTag(tag)"
-      filter
-    />
-  </v-chip-group>
+    <v-chip-group
+      :model-value="modelValue"
+      @update:modelValue="$emit('update:modelValue', $event)"
+      multiple
+    >
+      <tag-chip
+        v-for="(tag, index) in availableTags.length > 0
+          ? availableTags
+          : allTags"
+        :key="index"
+        :tag="tag"
+        :count="getCountOfTag(tag)"
+        filter
+      />
+    </v-chip-group>
   </div>
 </template>
+
 <style scoped></style>

--- a/.vitepress/theme/enhancements/i18n/lang/de.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/de.ts
@@ -26,4 +26,7 @@ export const deMessages: localizedMessagesType = {
     start2024: "Start 2024",
     support: "Support",
   },
+  TagFilter: {
+    clearAll: "Alle löschen",
+  },
 };

--- a/.vitepress/theme/enhancements/i18n/lang/de.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/de.ts
@@ -27,6 +27,6 @@ export const deMessages: localizedMessagesType = {
     support: "Support",
   },
   TagFilter: {
-    clearAll: "Alle löschen",
+    clearAll: "Alle tags löschen",
   },
 };

--- a/.vitepress/theme/enhancements/i18n/lang/en.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/en.ts
@@ -26,4 +26,7 @@ export const enMessages: localizedMessagesType = {
     start2024: "Start 2024",
     support: "Support",
   },
+  TagFilter: {
+    clearAll: "Clear All",
+  },
 };

--- a/.vitepress/theme/enhancements/i18n/lang/en.ts
+++ b/.vitepress/theme/enhancements/i18n/lang/en.ts
@@ -27,6 +27,6 @@ export const enMessages: localizedMessagesType = {
     support: "Support",
   },
   TagFilter: {
-    clearAll: "Clear All",
+    clearAll: "Clear all tags",
   },
 };


### PR DESCRIPTION
**This PR adds a way to reset the active tag filters after selecting multiple tags.**

Changes made:

Added a clear all chip to the tag filter component
showed the clear action only when more than one tag is selected
reset the selected tag list by emitting an empty model value
consolidated defineEmits into a single const emit = defineEmits(...) to resolve duplicate declaration and enable reuse
kept the existing tag filtering behavior unchanged

**Closes issue #38**

Issues #38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized "Clear all" control to the tag filter that removes all selected tags at once.
  * Control appears only when multiple tags are selected.
  * English and German translations for the control label have been added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->