### PR TITLE
Feat/language auto detect

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,4 +1,6 @@
+import { useRouter } from "vitepress";
 import DefaultTheme from "vitepress/theme";
+import { onMounted, onUnmounted } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -13,6 +15,8 @@ import LhmThemeExtension from "./LhmThemeExtension.vue";
 
 import "./lhm.css";
 
+const MANUAL_LANGUAGE_STORAGE_KEY = "manual-language";
+
 const vuetify = createVuetify({
   components,
   directives,
@@ -25,10 +29,115 @@ const vuetify = createVuetify({
   },
 });
 
+function getPreferredBrowserLanguage(): string {
+  const languages = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+  const primaryLanguage = languages[0]?.toLowerCase() ?? "en";
+
+  return primaryLanguage.startsWith("de") ? "de" : "en";
+}
+
+function isGermanPath(path: string): boolean {
+  return path === "/de/" || path.startsWith("/de/");
+}
+
+function persistLanguageFromPath(path: string): void {
+  localStorage.setItem(
+    MANUAL_LANGUAGE_STORAGE_KEY,
+    isGermanPath(path) ? "de" : "en"
+  );
+}
+
+function getStoredLanguage(): string | null {
+  const storedLanguage = localStorage.getItem(MANUAL_LANGUAGE_STORAGE_KEY);
+
+  if (storedLanguage === "de" || storedLanguage === "en") {
+    return storedLanguage;
+  }
+
+  return null;
+}
+
+function getLocalizedPath(path: string, language: string): string {
+  if (language === "de") {
+    return isGermanPath(path) ? path : `/de${path}`;
+  }
+
+  if (!isGermanPath(path)) {
+    return path;
+  }
+
+  const englishPath = path.replace(/^\/de/, "");
+  return englishPath || "/";
+}
 export default {
   ...DefaultTheme,
   Layout: LhmThemeExtension,
   enhanceApp({ app }) {
     app.use(vuetify);
+  },
+
+  setup() {
+    const router = useRouter();
+    const handleLanguageSelection = (event: MouseEvent): void => {
+      const target = event.target;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const languageSwitcher = target.closest(
+        ".VPNavBarTranslations, .VPNavScreenTranslations"
+      );
+
+      if (!languageSwitcher) {
+        return;
+      }
+
+      const link = target.closest("a");
+
+      if (!link) {
+        return;
+      }
+
+      const href = link.getAttribute("href");
+
+      if (!href) {
+        return;
+      }
+
+      const nextUrl = new URL(href, window.location.origin);
+
+      if (nextUrl.origin !== window.location.origin) {
+        return;
+      }
+
+      persistLanguageFromPath(nextUrl.pathname);
+    };
+
+    onMounted(() => {
+      const currentPath = window.location.pathname;
+      const currentSearch = window.location.search;
+      const currentHash = window.location.hash;
+      const storedLanguage = getStoredLanguage();
+      const browserLanguage = getPreferredBrowserLanguage();
+      const targetLang = storedLanguage ?? browserLanguage;
+      const localizedPath = getLocalizedPath(currentPath, targetLang);
+
+      if (localizedPath !== currentPath) {
+        void router.go(`${localizedPath}${currentSearch}${currentHash}`);
+      }
+
+      document.addEventListener("click", handleLanguageSelection, {
+        capture: true,
+      });
+    });
+
+    onUnmounted(() => {
+      document.removeEventListener("click", handleLanguageSelection, {
+        capture: true,
+      });
+    });
   },
 };

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "vitepress";
 import DefaultTheme from "vitepress/theme";
-import { onMounted, onUnmounted } from "vue";
+import { onMounted } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -71,6 +71,7 @@ function getLocalizedPath(path: string, language: string): string {
   const englishPath = path.replace(/^\/de/, "");
   return englishPath || "/";
 }
+
 export default {
   ...DefaultTheme,
   Layout: LhmThemeExtension,
@@ -80,40 +81,26 @@ export default {
 
   setup() {
     const router = useRouter();
-    const handleLanguageSelection = (event: MouseEvent): void => {
-      const target = event.target;
+    let previousPath = "";
+    let skipNextLocalePersistence = false;
 
-      if (!(target instanceof Element)) {
+    router.onAfterRouteChange = (to) => {
+      const nextPath = new URL(to, window.location.origin).pathname;
+
+      if (skipNextLocalePersistence) {
+        skipNextLocalePersistence = false;
+        previousPath = nextPath;
         return;
       }
 
-      const languageSwitcher = target.closest(
-        ".VPNavBarTranslations, .VPNavScreenTranslations"
-      );
-
-      if (!languageSwitcher) {
-        return;
+      if (
+        previousPath &&
+        isGermanPath(previousPath) !== isGermanPath(nextPath)
+      ) {
+        persistLanguageFromPath(nextPath);
       }
 
-      const link = target.closest("a");
-
-      if (!link) {
-        return;
-      }
-
-      const href = link.getAttribute("href");
-
-      if (!href) {
-        return;
-      }
-
-      const nextUrl = new URL(href, window.location.origin);
-
-      if (nextUrl.origin !== window.location.origin) {
-        return;
-      }
-
-      persistLanguageFromPath(nextUrl.pathname);
+      previousPath = nextPath;
     };
 
     onMounted(() => {
@@ -125,19 +112,12 @@ export default {
       const targetLang = storedLanguage ?? browserLanguage;
       const localizedPath = getLocalizedPath(currentPath, targetLang);
 
+      previousPath = currentPath;
+
       if (localizedPath !== currentPath) {
+        skipNextLocalePersistence = true;
         void router.go(`${localizedPath}${currentSearch}${currentHash}`);
       }
-
-      document.addEventListener("click", handleLanguageSelection, {
-        capture: true,
-      });
-    });
-
-    onUnmounted(() => {
-      document.removeEventListener("click", handleLanguageSelection, {
-        capture: true,
-      });
     });
   },
 };


### PR DESCRIPTION
**Description**

Added automatic language detection so the site defaults to the browser’s primary language on first load, switching between the English and German route trees as needed.

Also, added persistence for manual language selection by storing the chosen locale in localStorage. This is for when a user selects a language via the built in language chooser; that preference overrides browser detection on subsequent visits. (Ex: I have my browser in English, I change the site to Deutsch, when I revisit it will save my choice)

Detection is handled at the theme level using `navigator.languages`, and existing VitePress locale routing and translation behavior is unchanged.

**Reference**

Issues #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language support with automatic detection for German and English content.
  * Language preferences are now persisted locally, maintaining user selections across browser sessions.
  * Implemented intelligent routing to serve localized content based on browser language detection and stored user preferences, with automatic redirects to appropriate language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->