### PR TITLE
trivy

### DIFF
--- a/de/security.md
+++ b/de/security.md
@@ -48,8 +48,9 @@ Dies erleichtert zwar die Sicherheitsbewertung, birgt aber auch Risiken, wenn et
 
 ### Automatisierte Tests
 
-Der interne CI/CD-Prozess umfasst den [OWASP](https://de.wikipedia.org/wiki/Open_Worldwide_Application_Security_Project) Dependency Check zur Risikoanalyse.
-Auf GitHub muss in allen Repositories [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) implementiert werden, und die globale Sicherheitskonfiguration (z.B. Dependabot alerts) muss für alle Repositories aktiviert sein.
+In allen CI/CD-Prozessen nutzen wir [Trivy](https://trivy.dev/).
+Auf GitHub nutzen wir dazu [action-trivy](https://github.com/it-at-m/lhm_actions/tree/main/action-templates/actions/action-trivy/action.yml).
+Zusätzlich muss in allen Repositories [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) implementiert werden, und die globale Sicherheitskonfiguration (z.B. Dependabot alerts) muss für alle Repositories aktiviert sein.
 
 Sicherheitsrelevante Pull Requests und Issues mit den [CVSS crtical und high](https://nvd.nist.gov/vuln-metrics/cvss) müssen innerhalb von __30 Tagen__ bearbeitet werden. Nach dieser Frist werden sie an die jeweiligen [Maintainer](https://de.wikipedia.org/wiki/Maintainer) weitergeleitet.
 

--- a/de/security.md
+++ b/de/security.md
@@ -52,7 +52,7 @@ In allen CI/CD-Prozessen nutzen wir [Trivy](https://trivy.dev/).
 Auf GitHub nutzen wir dazu [action-trivy](https://github.com/it-at-m/lhm_actions/tree/main/action-templates/actions/action-trivy/action.yml).
 Zusätzlich muss in allen Repositories [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) implementiert werden, und die globale Sicherheitskonfiguration (z.B. Dependabot alerts) muss für alle Repositories aktiviert sein.
 
-Sicherheitsrelevante Pull Requests und Issues mit den [CVSS crtical und high](https://nvd.nist.gov/vuln-metrics/cvss) müssen innerhalb von __30 Tagen__ bearbeitet werden. Nach dieser Frist werden sie an die jeweiligen [Maintainer](https://de.wikipedia.org/wiki/Maintainer) weitergeleitet.
+Sicherheitsrelevante Pull Requests und Issues mit den [CVSS critical und high](https://nvd.nist.gov/vuln-metrics/cvss) müssen innerhalb von __30 Tagen__ bearbeitet werden. Nach dieser Frist werden sie an die jeweiligen [Maintainer](https://de.wikipedia.org/wiki/Maintainer) weitergeleitet.
 
 ### Responsible Disclosure
 

--- a/security.md
+++ b/security.md
@@ -51,7 +51,7 @@ Therefore, it is recommended to disable external visibility of the SBOM endpoint
 ### Automated Tests
 
 We use [Trivy](https://trivy.dev/) in all our CI/CD processes.
-On GitHub, we use [action-trivy](https://github.com/it-at-m/lhm_actions/tree/main/action-templates/actions/action-trivy/action.yml) for this purpose.
+On GitHub, we use [action-trivy](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-trivy/action.yml) for this purpose.
 In addition, [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) must be implemented in all repositories, and the global security configuration (e.g., Dependabot alerts) must be enabled for all repositories.
 
 Security-related pull requests and issues with a [CVSS critical and high](https://nvd.nist.gov/vuln-metrics/cvss) rating must be addressed within __30 days__.

--- a/security.md
+++ b/security.md
@@ -50,8 +50,9 @@ Therefore, it is recommended to disable external visibility of the SBOM endpoint
 
 ### Automated Tests
 
-The internal CI/CD process includes the [OWASP](https://de.wikipedia.org/wiki/Open_Worldwide_Application_Security_Project) Dependency Check for risk analysis.  
-On GitHub, [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) must be implemented in all repositories, and the global security configuration (e.g. Dependabot alerts) must be activated for all repositories.
+We use [Trivy](https://trivy.dev/) in all our CI/CD processes.
+On GitHub, we use [action-trivy](https://github.com/it-at-m/lhm_actions/tree/main/action-templates/actions/action-trivy/action.yml) for this purpose.
+In addition, [CodeQL](https://github.com/it-at-m/lhm_actions/blob/main/action-templates/actions/action-codeql/action.yml) must be implemented in all repositories, and the global security configuration (e.g., Dependabot alerts) must be enabled for all repositories.
 
 Security-related pull requests and issues with a [CVSS critical and high](https://nvd.nist.gov/vuln-metrics/cvss) rating must be addressed within __30 days__.
 


### PR DESCRIPTION
rem OWASP add trivy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security testing guidance: vulnerability scanning now standardizes on Trivy across CI/CD, with a note on using the Trivy GitHub Action where applicable.
  * Clarified that CodeQL usage and global security settings (e.g., Dependabot alerts) remain required.
  * Other security response and disclosure guidance unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->