### PR TITLE
Remove Size of SDS iFrame

### DIFF
--- a/de/software/sds-calculator.md
+++ b/de/software/sds-calculator.md
@@ -24,7 +24,7 @@ Ziel ist es, den Grad digitaler Souveränität auf einfache Weise in einem leich
 <iframe
 src="https://it-at-m.github.io/sds-calculator/"
 width="100%"
-height="900"
+height="750"
 style="border:1px solid #ddd; border-radius:8px;"
 loading="lazy"
 ></iframe>

--- a/software/sds-calculator.md
+++ b/software/sds-calculator.md
@@ -24,7 +24,7 @@ Its purpose is to provide a simple way to assess the degree of digital sovereign
   <iframe
     src="https://it-at-m.github.io/sds-calculator/"
     width="100%"
-    height="900"
+    height="750"
     style="border:1px solid #ddd; border-radius:8px;"
     loading="lazy"
   ></iframe>


### PR DESCRIPTION
**Description**

Reduced Size of iFrame, as copy section doesn't work in iFrames


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Optimized the display layout of the embedded SDS-Calculator tool across documentation pages, including localized versions, for improved visual presentation and better space utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/opensource.muenchen.de/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->