### PR TITLE
Fix broken links

### DIFF
--- a/de/principles.md
+++ b/de/principles.md
@@ -11,7 +11,7 @@ Die Landeshauptstadt München nutzt Open Source Software aus vielen Gründen.
 - Öffentlich zugänglicher Code lässt sich hinsichtlich [IT-Sicherheit](security) leicht überprüfen und  Sicherheitslücken auch ohne den Hersteller schließen.
 - Die **Transparenz** über die Software und ihre Entwicklung schafft Vertrauen in der Bevölkerung gegenüber der Verwaltung.
 - Engagierte Bürger\*innen können sich an **Projekten beteiligen** und somit innovative Ideen einbringen und das erforderliche städtische Budget reduzieren.
-- Public Code erzeugt eine positive Öffentlichkeitsarbeit und einen Beitrag zu unserem [Personalmarketing für IT-Schaffende](https://karriere.muenchen.de/search/?optionsFacetsDD_customfield3=Informationstechnologie+%28IT%29+%26+Telekommunikation).
+- Public Code erzeugt eine positive Öffentlichkeitsarbeit und einen Beitrag zu unserem [Personalmarketing für IT-Schaffende](https://karriere-muenchen.jobs.hr.cloud.sap/search/?q=&searchResultView=LIST&markerViewed=&carouselIndex=&facetFilters=%7B%22cust_BerufGr%22%3A%5B%22Informationstechnologie+%28IT%29+%26+Telekommunikation%22%5D%7D&pageNumber=0).
 
 ## Rechtliche und politische Vorgaben
 

--- a/de/software/bayernid-plugin.md
+++ b/de/software/bayernid-plugin.md
@@ -3,7 +3,7 @@ Source: SNow
 title: BayernID - Plugin
 developer: LHM
 code: https://github.com/it-at-m/BayernID-Plugin
-logo: https://id.bayernportal.de/cms/assets/images/64/BayernID_Icon-rund.625c9ab7.svg
+logo: https://id.bayernportal.de/cms/assets/images/64/BayernID_Icon-rund.Cyx-yXUx.svg
 licensingmodel: open source
 license: MIT
 opencode: https://opencode.de/de/software/bayern-id-plugin-fur-keycloak-rh-sso-27

--- a/principles.md
+++ b/principles.md
@@ -11,7 +11,7 @@ The City of Munich uses open source software for many reasons.
 - Publicly accessible code can be easily checked for [IT security](security) and security gaps can be closed even without the manufacturer.
 - The **transparency** about the software and its development creates trust in the population towards the administration.
 - Committed citizens can participate in **projects** and thus contribute innovative ideas and reduce the required municipal budget.
-- Public Code generates positive public relations and contributes to our [recruitment marketing for IT professionals](https://karriere.muenchen.de/search/?optionsFacetsDD_customfield3=Informationstechnologie+%28IT%29+%26+Telekommunikation).
+- Public Code generates positive public relations and contributes to our [recruitment marketing for IT professionals](https://karriere-muenchen.jobs.hr.cloud.sap/search/?q=&searchResultView=LIST&markerViewed=&carouselIndex=&facetFilters=%7B%22cust_BerufGr%22%3A%5B%22Informationstechnologie+%28IT%29+%26+Telekommunikation%22%5D%7D&pageNumber=0).
 
 ## Legal and political requirements
 

--- a/software/bayernid-plugin.md
+++ b/software/bayernid-plugin.md
@@ -3,7 +3,7 @@ Source: SNow
 title: BayernID - Plugin
 developer: LHM
 code: https://github.com/it-at-m/BayernID-Plugin
-logo: https://id.bayernportal.de/cms/assets/images/64/BayernID_Icon-rund.625c9ab7.svg
+logo: https://id.bayernportal.de/cms/assets/images/64/BayernID_Icon-rund.Cyx-yXUx.svg
 licensingmodel: open source
 license: MIT
 opencode: https://opencode.de/de/software/bayern-id-plugin-fur-keycloak-rh-sso-27


### PR DESCRIPTION
Fixes BayernID_Icon and karriere.muenchen.de links that retured 404 erros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recruitment marketing links in the German and English principles documentation.
  * Updated the BayernID plugin logo to the latest available image asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->