### PR TITLE
Add broken link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,4 @@ jobs:
         max_retries: 2
         max_depth: 10
         connect_limit_per_host: 5
-        exclude_url_prefix: 'https://www.npmjs.com/search?q=%40muenchen,https://unsplash.com/de/,https://www.bsi.bund.de'
+        exclude_url_prefix: 'https://www.npmjs.com/search?q=%40muenchen,https://unsplash.com/de/,https://www.bsi.bund.de,https://www.bfdi.bund.de,https://www.gesetze-im-internet.de'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,11 +14,12 @@ jobs:
       uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
       with:
         website_url: 'https://opensource.muenchen.de'
-        verbose: 'warn'
+        verbose: 'true'
         max_retry_time: 10
         max_retries: 2
         max_depth: 10
         connect_limit_per_host: 1
+        always_get_onsite: 'true'
         exclude_url_prefix: |
           https://www.npmjs.com/search?q=%40muenchen,
           https://unsplash.com/de/,

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,9 +1,9 @@
 name: Check for broken links
 on: 
   workflow_dispatch:
-  push: # for testing
   schedule:
     - cron:  '0 4 * * 0' # at 04:00 on sunday
+
 jobs:
   link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,8 +1,8 @@
 name: Check for broken links
-on: 
+on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 4 * * 0' # at 04:00 on sunday
+    - cron: "0 4 * * 0" # at 04:00 on sunday
 
 permissions: {}
 jobs:
@@ -10,23 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for broken links
     steps:
-
-    - name: Check for broken links
-      uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
-      with:
-        website_url: 'https://opensource.muenchen.de'
-        verbose: 'true'
-        max_retry_time: 10
-        max_retries: 2
-        max_depth: 10
-        connect_limit_per_host: 1
-        always_get_onsite: 'true'
-        exclude_url_prefix: |
-          mailto:,
-          tel:,
-          https://www.npmjs.com/search?q=%40muenchen,
-          https://unsplash.com/de/,
-          https://www.bsi.bund.de,
-          https://www.bfdi.bund.de,
-          https://www.gesetze-im-internet.de,
-          https://github.com/it-at-m/opensource.muenchen.de
+      - name: Check for broken links
+        uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
+        with:
+          website_url: "https://opensource.muenchen.de"
+          verbose: "true"
+          max_retry_time: 10
+          max_retries: 2
+          max_depth: 10
+          connect_limit_per_host: 1
+          always_get_onsite: "true"
+          exclude_url_prefix: |
+            mailto:,
+            tel:,
+            https://www.npmjs.com/search?q=%40muenchen,
+            https://unsplash.com/de/,
+            https://www.bsi.bund.de,
+            https://www.bfdi.bund.de,
+            https://www.gesetze-im-internet.de,
+            https://github.com/it-at-m/opensource.muenchen.de

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,7 @@ jobs:
       uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
       with:
         website_url: 'https://opensource.muenchen.de'
-        verbose: 'false'
+        verbose: 'warn'
         max_retry_time: 10
         max_retries: 2
         max_depth: 10

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '0 4 * * 0' # at 04:00 on sunday
 
+permissions: {}
 jobs:
   link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Check for broken links
-      uses: ScholliYT/Broken-Links-Crawler-Action@v3
+      uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
       with:
         website_url: 'https://opensource.muenchen.de'
         verbose: 'true'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,20 @@
+name: Check for broken links
+on: 
+  workflow_dispatch:
+  push: # for testing
+  schedule:
+    - cron:  '0 4 * * 0' # at 04:00 on sunday
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    name: Check for broken links
+    steps:
+
+    - name: Check for broken links
+      uses: ScholliYT/Broken-Links-Crawler-Action@v3
+      with:
+        website_url: 'https://opensource.muenchen.de'
+        verbose: 'true'
+        max_retry_time: 30
+        max_retries: 5
+        max_depth: 1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,10 @@ jobs:
         max_retries: 2
         max_depth: 10
         connect_limit_per_host: 1
-        exclude_url_prefix: 'https://www.npmjs.com/search?q=%40muenchen,https://unsplash.com/de/,https://www.bsi.bund.de,https://www.bfdi.bund.de,https://www.gesetze-im-internet.de'
+        exclude_url_prefix: |
+          https://www.npmjs.com/search?q=%40muenchen,
+          https://unsplash.com/de/,
+          https://www.bsi.bund.de,
+          https://www.bfdi.bund.de,
+          https://www.gesetze-im-internet.de,
+          https://github.com/it-at-m/opensource.muenchen.de

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,9 +14,9 @@ jobs:
       uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3.3.2
       with:
         website_url: 'https://opensource.muenchen.de'
-        verbose: 'true'
+        verbose: 'false'
         max_retry_time: 10
         max_retries: 2
         max_depth: 10
-        connect_limit_per_host: 5
+        connect_limit_per_host: 1
         exclude_url_prefix: 'https://www.npmjs.com/search?q=%40muenchen,https://unsplash.com/de/,https://www.bsi.bund.de,https://www.bfdi.bund.de,https://www.gesetze-im-internet.de'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,6 +21,8 @@ jobs:
         connect_limit_per_host: 1
         always_get_onsite: 'true'
         exclude_url_prefix: |
+          mailto:,
+          tel:,
           https://www.npmjs.com/search?q=%40muenchen,
           https://unsplash.com/de/,
           https://www.bsi.bund.de,

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,4 +17,4 @@ jobs:
         verbose: 'true'
         max_retry_time: 30
         max_retries: 5
-        max_depth: 1
+        max_depth: 10

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,6 +15,8 @@ jobs:
       with:
         website_url: 'https://opensource.muenchen.de'
         verbose: 'true'
-        max_retry_time: 30
-        max_retries: 5
+        max_retry_time: 10
+        max_retries: 2
         max_depth: 10
+        connect_limit_per_host: 5
+        exclude_url_prefix: 'https://www.npmjs.com/search?q=%40muenchen,https://unsplash.com/de/,https://www.bsi.bund.de'


### PR DESCRIPTION
Adds a new github actions workflow, that checks `opensource.muenchen.de` for broken links automatically every week. The excludes are necessary because these sites block requests from github actions runners.