### PR TITLE
Extend renovate config from refarch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": [
+    "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5"
+  ]
 }


### PR DESCRIPTION
**Description**

Extend renovate config from refarch to set org defaults like enabling dependency pinning.

**Reference**

Issue [974](https://git.muenchen.de/ccse/ospo/-/work_items/974)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to use the project’s standardized Renovate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->