### PR TITLE
Add libexpat and sabbatical

### DIFF
--- a/de/sabbatical.md
+++ b/de/sabbatical.md
@@ -58,9 +58,9 @@ Zudem wird in diesem Sabbatical Wert auf die Nutzerfreundlichkeit und Barrierefr
 ### [libexpat](software/libexpat#open-source-sabbatical)
 
 Im zweiten Halbjahr 2026 haben wir ein Open Source Sabbatical an [libexpat](software/libexpat#open-source-sabbatical) vergeben.
-Neben der allgemeinen Softwarpflege und Weiterenwicklung werden folgenden Schwerpunkte angegangen:
+Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgenden Schwerpunkte angegangen:
 
-* [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
+* [Bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
 * [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
-* Erhöhung der Wartbarkeit von expat. (z.B. Codedokumentation, Testsuite verbessern)
+* Erhöhung der Wartbarkeit von Expat (z.B. mehr Code-Dokumentation, Testsuite verbessern)

--- a/de/sabbatical.md
+++ b/de/sabbatical.md
@@ -62,5 +62,5 @@ Neben der allgemeinen Softwarpflege und Weiterenwicklung werden folgenden Schwer
 
 * [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
-* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
 * Erhöhung der Wartbarkeit von expat. (z.B. Codedokumentation, Testsuite verbessern)

--- a/de/sabbatical.md
+++ b/de/sabbatical.md
@@ -54,3 +54,13 @@ Durch den Einsatz von Llama 3.3 und Google Gemma 3 wird eine effektive Kommunika
 Die bisherigen  Ergebnisse des Projekts sind vielversprechend: Der Chatbot liefert in etwa 50 % der Fälle hilfreiche und passende Antworten auf Anfragen. Die Übersetzungsqualität wurde mit 4,9 von 5 bewertet, während die Antwortqualität bei 4,0 von 5 liegt. Zudem wurde die Relevanz der verlinkten Inhalte mit 4,8 von 5 bewertet. Das durchweg positive Feedback der Nutzer*innen zeigt, dass der Chatbot nicht nur die Integreat-App interaktiver macht, sondern auch einen echten Mehrwert für die Integration und Unterstützung von Menschen mit Migrationshintergrund bietet.
 
 Zudem wird in diesem Sabbatical Wert auf die Nutzerfreundlichkeit und Barrierefreiheit gelegt, um sicherzustellen, dass alle Münchener Bürger*innen, unabhängig von ihrer Herkunft oder ihren Sprachkenntnissen, die Vorteile der Integreat-App optimal nutzen können.
+
+### [libexpat](software/libexpat#open-source-sabbatical)
+
+Im zweiten Halbjahr 2026 haben wir ein Open Source Sabbatical an [libexpat](software/libexpat#open-source-sabbatical) vergeben.
+Neben der allgemeinen Softwarpflege und Weiterenwicklung werden folgenden Schwerpunkte angegangen:
+
+* [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
+  * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
+* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* Erhöhung der Wartbarkeit von expat. (z.B. Codedokumentation, Testsuite verbessern)

--- a/de/sabbatical.md
+++ b/de/sabbatical.md
@@ -58,9 +58,9 @@ Zudem wird in diesem Sabbatical Wert auf die Nutzerfreundlichkeit und Barrierefr
 ### [libexpat](software/libexpat#open-source-sabbatical)
 
 Im zweiten Halbjahr 2026 haben wir ein Open Source Sabbatical an [libexpat](software/libexpat#open-source-sabbatical) vergeben.
-Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgenden Schwerpunkte angegangen:
+Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
 
 * [Bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
-* [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
+* [Unterstützung von XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
 * Erhöhung der Wartbarkeit von Expat (z.B. mehr Code-Dokumentation, Testsuite verbessern)

--- a/de/sabbatical.md
+++ b/de/sabbatical.md
@@ -58,7 +58,7 @@ Zudem wird in diesem Sabbatical Wert auf die Nutzerfreundlichkeit und Barrierefr
 ### [libexpat](software/libexpat#open-source-sabbatical)
 
 Im zweiten Halbjahr 2026 haben wir ein Open Source Sabbatical an [libexpat](software/libexpat#open-source-sabbatical) vergeben.
-Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
+Neben der allgemeinen Softwarepflege und Weiterentwicklung werden folgende Schwerpunkte angegangen:
 
 * [Bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -17,7 +17,7 @@ Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
 Expat ist eine typische sehr weit verbreitete Open Source Bibliothek die in unzähliger Soft- und auch Hardware vebaut ist.
 
 Allein bei der Landeshauptstadt Münchenist sie auf auf mindestens 2700 Linux Servern der installiert (per Scanner detektiert).
-Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python
+Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
 Aber auch in proprietäre Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
 
 

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -16,7 +16,7 @@ Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
 
 Expat ist eine typische, sehr weit verbreitete Open-Source-Bibliothek, die in unzähliger Soft- und auch Hardware verbaut ist.
 
-Allein bei der Landeshauptstadt München ist sie auf auf mindestens 2700 Linux-Servern installiert (per Scanner detektiert).
+Allein bei der Landeshauptstadt München ist sie auf mindestens 2.700 Linux-Servern installiert (per Scanner erkannt)
 Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
 Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115) wird libexpat zum Parsen von XML eingesetzt.
 
@@ -24,7 +24,7 @@ Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](
 ## Open Source Sabbatical
 
 Im zweiten Halbjahr 2026 haben wir ein [Open Source Sabbatical](../sabbatical) an den Maintainer von Expat vergeben.
-Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
+Neben der allgemeinen Softwarepflege und Weiterentwicklung werden folgende Schwerpunkte angegangen:
 
 * [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -17,7 +17,7 @@ Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
 Expat ist eine typische, sehr weit verbreitete Open-Source-Bibliothek, die in unzähliger Soft- und auch Hardware verbaut ist.
 
 Allein bei der Landeshauptstadt München ist sie auf mindestens 2.700 Linux-Servern installiert (per Scanner erkannt).
-Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
+Beispielsweise unser Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
 Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115) wird libexpat zum Parsen von XML eingesetzt.
 
 

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -14,19 +14,19 @@ Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
 
 ---
 
-Expat ist eine typische sehr weit verbreitete Open Source Bibliothek die in unzähliger Soft- und auch Hardware vebaut ist.
+Expat ist eine typische, sehr weit verbreitete Open-Source-Bibliothek, die in unzähliger Soft- und auch Hardware verbaut ist.
 
-Allein bei der Landeshauptstadt Münchenist sie auf auf mindestens 2700 Linux Servern der installiert (per Scanner detektiert).
+Allein bei der Landeshauptstadt München ist sie auf auf mindestens 2700 Linux-Servern installiert (per Scanner detektiert).
 Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
-Aber auch in proprietäre Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
+Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115) wird libexpat zum Parsen von XML eingesetzt.
 
 
 ## Open Source Sabbatical
 
-Im zweiten Halbjahr 2026 habe wir ein [Open Source Sabbatical](../sabbatical) an den Maintainer von Expat vergeben.
-Neben der allgemeinen Softwarpflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
+Im zweiten Halbjahr 2026 haben wir ein [Open Source Sabbatical](../sabbatical) an den Maintainer von Expat vergeben.
+Neben der allgemeinen Softwarepflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
 
 * [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
-* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
-* Erhöhung der Wartbarkeit von expat. (z.B. Codedokumentation, Testsuite verbessern)
+* [Unterstützung von XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
+* Erhöhung der Wartbarkeit von Expat (z.B. mehr Code-Dokumentation, Testsuite verbessern)

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -26,7 +26,7 @@ Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](
 Im zweiten Halbjahr 2026 haben wir ein [Open Source Sabbatical](../sabbatical) an den Maintainer von Expat vergeben.
 Neben der allgemeinen Softwarepflege und Weiterentwicklung werden folgende Schwerpunkte angegangen:
 
-* [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
+* [Bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
   * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
 * [Unterstützung von XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
 * Erhöhung der Wartbarkeit von Expat (z.B. mehr Code-Dokumentation, Testsuite verbessern)

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -1,0 +1,32 @@
+---
+title: libexpat
+developer: Expat maintainers
+developerlink: https://libexpat.github.io/
+code: https://github.com/libexpat/libexpat
+licensingmodel: open source
+license: MIT
+tags:
+  - infrastruktur
+sortingPriority: 1
+---
+
+Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
+
+---
+
+Expat ist eine typische sehr weit verbreitete Open Source Bibliothek die in unzähliger Soft- und auch Hardware vebaut ist.
+
+Allein bei der Landeshauptstadt Münchenist sie auf auf mindestens 2700 Linux Servern der installiert (per Scanner detektiert).
+Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python
+Aber auch in proprietäre Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
+
+
+## Open Source Sabbatical
+
+Im zweiten Halbjahr 2026 habe wir ein [Open Source Sabbatical](../sabbatical) an den Maintainer von Expat vergeben.
+Neben der allgemeinen Softwarpflege und Weiterenwicklung werden folgende Schwerpunkte angegangen:
+
+* [bereits bekannte und ungefixte Sicherheitslücken](https://github.com/libexpat/libexpat/issues/1160) beheben.
+  * Abarbeitung weiterer Sicherheitslücken, die im Zuge der aktuellen Flut von Sicherheitsanalysen gemeldet werden.
+* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* Erhöhung der Wartbarkeit von expat. (z.B. Codedokumentation, Testsuite verbessern)

--- a/de/software/libexpat.md
+++ b/de/software/libexpat.md
@@ -16,7 +16,7 @@ Expat ist eine in C geschriebene, streamorientierte XML-1.0-Parser-Bibliothek.
 
 Expat ist eine typische, sehr weit verbreitete Open-Source-Bibliothek, die in unzähliger Soft- und auch Hardware verbaut ist.
 
-Allein bei der Landeshauptstadt München ist sie auf mindestens 2.700 Linux-Servern installiert (per Scanner erkannt)
+Allein bei der Landeshauptstadt München ist sie auf mindestens 2.700 Linux-Servern installiert (per Scanner erkannt).
 Beispielsweise unseren Standardbrowser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity) und Python nutzen libexpat.
 Aber auch in proprietärer Software wie z.B. unserer [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115) wird libexpat zum Parsen von XML eingesetzt.
 

--- a/sabbatical.md
+++ b/sabbatical.md
@@ -66,7 +66,7 @@ This sabbatical also places emphasis on usability and accessibility to ensure th
 In the second half of 2026, we awarded an open-source sabbatical to [libexpat](software/libexpat#open-source-sabbatical).
 In addition to general software maintenance and further development, the following priorities will be addressed:
 
-* Fix [Unfixed non-public security issues](https://github.com/libexpat/libexpat/issues/1160).
+* Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).
   * Address additional security vulnerabilities reported as part of the current flood of security analyses.
 * [Support for XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
 * Improving the maintainability of Expat (e.g. more code documentation, improving the test suite)

--- a/sabbatical.md
+++ b/sabbatical.md
@@ -59,3 +59,14 @@ By using Llama 3.3 and Google Gemma 3, effective communication is ensured, capab
 The project’s results so far are promising: in roughly 50% of cases, the chatbot provides helpful and appropriate responses to queries. Translation quality has been rated at 4.9 out of 5, while answer quality is rated at 4.0 out of 5. Additionally, the relevance of linked content has been rated at 4.8 out of 5. The consistently positive feedback from users shows that the chatbot not only makes the Integreat App more interactive but also provides real added value for the integration and support of people with a migration background.
 
 This sabbatical also places emphasis on usability and accessibility to ensure that all Munich residents, regardless of their background or language skills, can make the best possible use of the advantages of the Integreat App.
+
+
+### [libexpat](software/libexpat#open-source-sabbatical)
+
+In the second half of 2026, we awarded an open-source sabbatical to [libexpat](software/libexpat#open-source-sabbatical).
+In addition to general software maintenance and further development, the following priorities will be addressed:
+
+* Fix [Unfixed non-public security issues](https://github.com/libexpat/libexpat/issues/1160).
+  * Address additional security vulnerabilities reported as part of the current flood of security analyses.
+* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* Improving the maintainability of expat. (e.g., improving code documentation and the test suite)

--- a/sabbatical.md
+++ b/sabbatical.md
@@ -68,5 +68,5 @@ In addition to general software maintenance and further development, the followi
 
 * Fix [Unfixed non-public security issues](https://github.com/libexpat/libexpat/issues/1160).
   * Address additional security vulnerabilities reported as part of the current flood of security analyses.
-* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
-* Improving the maintainability of expat. (e.g., improving code documentation and the test suite)
+* [Support for XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
+* Improving the maintainability of Expat (e.g. more code documentation, improving the test suite)

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -28,5 +28,5 @@ In addition to general software maintenance and further development, the followi
 
 * Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).
   * Addressing additional security vulnerabilities reported as part of the current flood of security analyses.
-* [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
+* [Support for XML 1.0r5](https://github.com/libexpat/libexpat/issues/171).
 * Improving the maintainability of Expat (e.g. more code documentation, improving the test suite)

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -17,7 +17,7 @@ Expat is a stream-oriented XML 1.0 parser library written in C.
 Expat is a typical, widely used open-source library that is integrated into countless software and hardware applications.
 
 In the city of Munich alone, it is installed on at least 2,700 Linux servers (as detected by a scanner).
-For example, our default browser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity), and Python
+For example, our default browser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity), and Python use libexpat.
 But it’s also used in proprietary software, such as our [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
 
 

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -29,4 +29,4 @@ In addition to general software maintenance and further development, the followi
 * Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).
   * Addressing additional security vulnerabilities reported as part of the current flood of security analyses.
 * [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
-* Improving the maintainability of expat. (e.g. code documentation, improving the test suite)
+* Improving the maintainability of Expat (e.g. more code documentation, improving the test suite)

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -28,5 +28,5 @@ In addition to general software maintenance and further development, the followi
 
 * Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).
   * Addressing additional security vulnerabilities reported as part of the current flood of security analyses.
-* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* [Support for XML 1.0r5/1.1](https://github.com/libexpat/libexpat/issues/171).
 * Improving the maintainability of expat. (e.g. code documentation, improving the test suite)

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -18,12 +18,12 @@ Expat is a typical, widely used open-source library that is integrated into coun
 
 In the city of Munich alone, it is installed on at least 2,700 Linux servers (as detected by a scanner).
 For example, our default browser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity), and Python use libexpat.
-But it’s also used in proprietary software, such as our [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
+But it's also used in proprietary software, such as our [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
 
 
 ## Open Source Sabbatical
 
-In the second half of 2026, we will be offering an [Open Source Sabbatical](../sabbatical) to the maintainer of expat.
+In the second half of 2026, we will be offering an [Open Source Sabbatical](../sabbatical) to the maintainer of Expat.
 In addition to general software maintenance and further development, the following priorities will be addressed:
 
 * Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).

--- a/software/libexpat.md
+++ b/software/libexpat.md
@@ -1,0 +1,32 @@
+---
+title: libexpat
+developer: Expat maintainers
+developerlink: https://libexpat.github.io/
+code: https://github.com/libexpat/libexpat
+licensingmodel: open source
+license: MIT
+tags:
+  - infrastruktur
+sortingPriority: 1
+---
+
+Expat is a stream-oriented XML 1.0 parser library written in C.
+
+---
+
+Expat is a typical, widely used open-source library that is integrated into countless software and hardware applications.
+
+In the city of Munich alone, it is installed on at least 2,700 Linux servers (as detected by a scanner).
+For example, our default browser [Firefox](./firefox), [QGIS](./qgis), [WinSCP](winscp), [Audacity](./audacity), and Python
+But it’s also used in proprietary software, such as our [Web Application Firewall](https://my.f5.com/manage/s/article/K000158115).
+
+
+## Open Source Sabbatical
+
+In the second half of 2026, we will be offering an [Open Source Sabbatical](../sabbatical) to the maintainer of expat.
+In addition to general software maintenance and further development, the following priorities will be addressed:
+
+* Fix [already known and unfixed security vulnerabilities](https://github.com/libexpat/libexpat/issues/1160).
+  * Addressing additional security vulnerabilities reported as part of the current flood of security analyses.
+* [Support for XML 1.0r5/1.1 ](https://github.com/libexpat/libexpat/issues/171).
+* Improving the maintainability of expat. (e.g. code documentation, improving the test suite)


### PR DESCRIPTION
add  libexpat and [sabbatical](https://opensource.muenchen.de/de/sabbatical.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Added libexpat documentation covering its purpose, licensing, repository, usage examples, and adoption.
- Documented a planned Open Source Sabbatical for the second half of 2026.
- Listed planned priorities including security fixes, XML 1.0r5/1.1 support, improved maintainability, expanded documentation, and test-suite enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->