### PR TITLE
link heading licenses

### DIFF
--- a/de/licenses.md
+++ b/de/licenses.md
@@ -1,3 +1,5 @@
+# Lizenzen
+
 Freie Software wird über den offenen Zugang zum Quellcode, vor allem aber über die lizenzrechtlichen Eigenschaften definiert.
 
 > Nachfolgend beschreiben wir rein informatorisch unsere Praxis; eine irgendwie geartete Empfehlung, so vorzugehen, ist damit ausdrücklich nicht verbunden.

--- a/de/usability-analysis.md
+++ b/de/usability-analysis.md
@@ -3,6 +3,11 @@
 Um existierende freie Software zu nutzen oder sogar weiter entwickeln zu können muss diese zunächst einer __Nutzbarkeitsanalyse__ unterzogen werden.
 Diese soll jegliche freie Software, unabhängig ob diese als Framework, Library, [Entwicklungstools](./in-house-development.html) [fertige Software](./use.html) eingesetzt werden soll, durchlaufen.
 
+## Lizenzen
+
+Wird eine [OSI Approved Licenses](https://opensource.org/licenses) genutzt.
+
+
 ## Code Review
 
 Die Bewertung des Codes erfolgt durch erfahrene Entwickler*innen, die mit der verwendeten Sprache und Technologie vertraut sind.

--- a/de/usability-analysis.md
+++ b/de/usability-analysis.md
@@ -5,7 +5,7 @@ Diese soll jegliche freie Software, unabhängig ob diese als Framework, Library,
 
 ## Lizenzen
 
-Wird eine [OSI Approved Licenses](https://opensource.org/licenses) genutzt.
+Eine [OSI Approved License](https://opensource.org/licenses) wird genutzt.
 
 
 ## Code Review

--- a/licenses.md
+++ b/licenses.md
@@ -1,3 +1,5 @@
+# Licenses
+
 Free software is defined by open access to the source code, but above all by its licence characteristics.
 
 > The following is a purely informative description of our practice; it is expressly not a recommendation of any kind to proceed in this way.

--- a/usability-analysis.md
+++ b/usability-analysis.md
@@ -3,6 +3,10 @@
 In order to use or even further develop existing free software, it must first be subjected to a __usability analysis__.
 All free software should undergo this, regardless of whether it is to be used as a framework, library, [development tools](./in-house-development.html) or as [finished software](./use.html).
 
+## Licenses
+
+An [OSI-Approved License](https://opensource.org/licenses) is used.
+
 ## Code review
 
 The code is evaluated by experienced developers who are familiar with the language and technology used.


### PR DESCRIPTION
add link and heading licenses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear “Licenses” headings to the licensing documentation in English and German.
  * Added a new usability-analysis section documenting the requirement to use an OSI-approved software license in both language versions.
  * Improved the organization and discoverability of licensing information for readers reviewing project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->